### PR TITLE
Fix InterruptedException handling to restore interrupt status (Fix #13)

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/RecordWorkoutActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/RecordWorkoutActivity.java
@@ -181,6 +181,8 @@ public class RecordWorkoutActivity extends FitoTrackActivity implements Location
                     mHandler.post(this::updateDescription);
                 }
             }catch (InterruptedException e){
+                // Restore the interrupt status to ensure the caller is aware of the interruption.
+                Thread.currentThread().interrupt();
                 e.printStackTrace();
             }
         }).start();


### PR DESCRIPTION
## Fix InterruptedException Handling (Issue #13)

### 🔴 Problem
- SonarQube detected that `InterruptedException` is caught but the interrupt status is not restored.
- This can cause the thread to ignore interruptions, leading to unexpected behaviour.

### ✅ Fix
- Restored the interrupt status by calling `Thread.currentThread().interrupt();`.

### 🔗 Related Issue
Fixes #13

---
