### PR TITLE
Declare "dateTextView" and all following declarations on a separate line

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/EnterWorkoutActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/EnterWorkoutActivity.java
@@ -46,7 +46,10 @@ import de.tadris.fitness.util.unit.UnitUtils;
 public class EnterWorkoutActivity extends InformationActivity implements SelectWorkoutTypeDialog.WorkoutTypeSelectListener, DatePickerFragment.DatePickerCallback, TimePickerFragment.TimePickerCallback, DurationPickerDialogFragment.DurationPickListener {
 
     WorkoutBuilder workoutBuilder = new WorkoutBuilder();
-    TextView typeTextView, dateTextView, timeTextView, durationTextView;
+    TextView typeTextView;
+    TextView dateTextView;
+    TextView timeTextView;
+    TextView durationTextView;
     EditText distanceEditText, commentEditText;
 
     @Override


### PR DESCRIPTION
### Declare "dateTextView" and all following declarations on a separate line (Issue https://github.com/SOEN6431Winter2025/FitoTrackW25/issues/19)

### 🔴 Problem
SonarQube detected that multiple variables should not be declared on the same line as it impacts code maintainability.
Declaring multiple variables on one line is difficult to read.

### ✅ Fix
Declared all the variables typeTextView, dateTextView, timeTextView, durationTextView

### 🔗 Related Issue
Fixes https://github.com/SOEN6431Winter2025/FitoTrackW25/issues/19