### PR TITLE
Fix#39 Refactor Duplicate dialog code in SettingsActivity and VoiceAnnouncementSettingsActivity

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/DialogUtils.java
+++ b/app/src/main/java/de/tadris/fitness/activity/DialogUtils.java
@@ -1,0 +1,31 @@
+package de.tadris.fitness.util;
+
+import android.widget.NumberPicker;
+import android.view.View;
+import android.app.AlertDialog;
+
+import de.tadris.fitness.R;
+
+public class DialogUtils {
+
+    public static void setUpDialog(AlertDialog.Builder dialogBuilder, View v, String positiveButtonText, DialogOnClickListener onPositiveClick) {
+        dialogBuilder.setView(v);
+        dialogBuilder.setNegativeButton(R.string.cancel, null);
+        dialogBuilder.setPositiveButton(positiveButtonText, (dialog, which) -> {
+            if (onPositiveClick != null) {
+                onPositiveClick.onClick(dialog, which);
+            }
+        });
+    }
+
+    public static void setUpNumberPicker(NumberPicker np, int minValue, int maxValue, String formatterText) {
+        np.setMinValue(minValue);
+        np.setMaxValue(maxValue);
+        np.setFormatter(value -> value == 0 ? "No speech" : value + formatterText);
+        np.setWrapSelectorWheel(false);  
+    }
+
+    public interface DialogOnClickListener {
+        void onClick(AlertDialog dialog, int which);
+    }
+}

--- a/app/src/main/java/de/tadris/fitness/activity/SettingsActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/SettingsActivity.java
@@ -214,30 +214,32 @@ public class SettingsActivity extends FitoTrackSettingsActivity {
     }
 
     private void showWeightPicker() {
-        UnitUtils.setUnit(this); // Maybe the user changed unit system
+        UnitUtils.setUnit(this); 
 
         final AlertDialog.Builder d = new AlertDialog.Builder(this);
-        final SharedPreferences preferences= PreferenceManager.getDefaultSharedPreferences(this);
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
         d.setTitle(getString(R.string.pref_weight));
-        View v= getLayoutInflater().inflate(R.layout.dialog_weight_picker, null);
+
+        View v = getLayoutInflater().inflate(R.layout.dialog_weight_picker, null);
         NumberPicker np = v.findViewById(R.id.weightPicker);
-        np.setMaxValue((int) UnitUtils.CHOSEN_SYSTEM.getWeightFromKilogram(150));
-        np.setMinValue((int) UnitUtils.CHOSEN_SYSTEM.getWeightFromKilogram(20));
-        np.setFormatter(value -> value + " " + UnitUtils.CHOSEN_SYSTEM.getWeightUnit());
+
+        int minValue = (int) UnitUtils.CHOSEN_SYSTEM.getWeightFromKilogram(20);
+        int maxValue = (int) UnitUtils.CHOSEN_SYSTEM.getWeightFromKilogram(150);
+        String weightUnit = UnitUtils.CHOSEN_SYSTEM.getWeightUnit();
+
+        DialogUtils.setUpWeightPicker(np, minValue, maxValue, weightUnit);
+
         final String preferenceVariable = "weight";
-        np.setValue((int)Math.round(UnitUtils.CHOSEN_SYSTEM.getWeightFromKilogram(preferences.getInt(preferenceVariable, 80))));
-        np.setWrapSelectorWheel(false);
+        np.setValue((int) Math.round(UnitUtils.CHOSEN_SYSTEM.getWeightFromKilogram(preferences.getInt(preferenceVariable, 80))));
 
-        d.setView(v);
-
-        d.setNegativeButton(R.string.cancel, null);
-        d.setPositiveButton(R.string.okay, (dialog, which) -> {
-            int unitValue= np.getValue();
-            int kilograms= (int)Math.round(UnitUtils.CHOSEN_SYSTEM.getKilogramFromUnit(unitValue));
+        DialogUtils.setUpDialog(d, v, getString(R.string.okay), (dialog, which) -> {
+        
+            int unitValue = np.getValue();
+            int kilograms = (int) Math.round(UnitUtils.CHOSEN_SYSTEM.getKilogramFromUnit(unitValue));
             preferences.edit().putInt(preferenceVariable, kilograms).apply();
         });
 
-        d.create().show();
-    }
+    d.create().show();
+}
 
 }

--- a/app/src/main/java/de/tadris/fitness/activity/VoiceAnnouncementsSettingsActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/VoiceAnnouncementsSettingsActivity.java
@@ -51,7 +51,7 @@ public class VoiceAnnouncementsSettingsActivity extends FitoTrackSettingsActivit
     }
 
     private void showSpeechConfig() {
-        UnitUtils.setUnit(this); // Maybe the user changed unit system
+        UnitUtils.setUnit(this); 
 
         final AlertDialog.Builder d = new AlertDialog.Builder(this);
         final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
@@ -59,32 +59,25 @@ public class VoiceAnnouncementsSettingsActivity extends FitoTrackSettingsActivit
         View v = getLayoutInflater().inflate(R.layout.dialog_spoken_updates_picker, null);
 
         NumberPicker npT = v.findViewById(R.id.spokenUpdatesTimePicker);
-        npT.setMaxValue(60);
-        npT.setMinValue(0);
-        npT.setFormatter(value -> value == 0 ? "No speech" : value + " min");
+        String timeFormatterText = " min"; 
+        DialogUtils.setUpNumberPicker(npT, 0, 60, timeFormatterText);  
         final String updateTimeVariable = "spokenUpdateTimePeriod";
         npT.setValue(preferences.getInt(updateTimeVariable, 0));
-        npT.setWrapSelectorWheel(false);
 
-        final String distanceUnit = " " + UnitUtils.CHOSEN_SYSTEM.getLongDistanceUnit();
+        String distanceUnit = " " + UnitUtils.CHOSEN_SYSTEM.getLongDistanceUnit();
         NumberPicker npD = v.findViewById(R.id.spokenUpdatesDistancePicker);
-        npD.setMaxValue(10);
-        npD.setMinValue(0);
-        npD.setFormatter(value -> value == 0 ? "No speech" : value + distanceUnit);
+        DialogUtils.setUpNumberPicker(npD, 0, 10, distanceUnit);  
         final String updateDistanceVariable = "spokenUpdateDistancePeriod";
         npD.setValue(preferences.getInt(updateDistanceVariable, 0));
-        npD.setWrapSelectorWheel(false);
 
-        d.setView(v);
-
-        d.setNegativeButton(R.string.cancel, null);
-        d.setPositiveButton(R.string.okay, (dialog, which) ->
-                preferences.edit()
-                        .putInt(updateTimeVariable, npT.getValue())
-                        .putInt(updateDistanceVariable, npD.getValue())
-                        .apply());
+        DialogUtils.setUpDialog(d, v, getString(R.string.okay), (dialog, which) -> {
+            preferences.edit()
+                    .putInt(updateTimeVariable, npT.getValue())
+                    .putInt(updateDistanceVariable, npD.getValue())
+                    .apply();
+        });
 
         d.create().show();
-    }
+}
 
 }


### PR DESCRIPTION
Clone deatils: 
Found duplicated clone in both SettingsActivity and VoiceAnnouncementSettingsActivity classes. The classes share identical dialog configuration code. This should be handled by creating a utility class.

Solution -
I plan to refactor by moving the duplicated dialog creation code to a reusable helper method in a utility class. I will create a DialogUtils class with a showDialog method that accepts parameters for the title, message, and button actions. The showWeightPicker method in SettingsActivity and VoiceAnnouncementsSettingsActivity will then call this utility method instead of duplicating the dialog setup code. This eliminates code redundancy while maintaining the same functionality across both activities.

Related IssueLink-
[Issue Link:](https://github.com/SOEN6431Winter2025/FitoTrackW25/issues/39 )

