### PR TITLE
Fix: "ACCESS_FINE_LOCATION" permission is necessary#52

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/RecordWorkoutActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/RecordWorkoutActivity.java
@@ -258,6 +258,12 @@ public class RecordWorkoutActivity extends FitoTrackActivity implements Location
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, 10);
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_COARSE_LOCATION}, 10);
         }
+
+        else {
+            startListener();  
+        }
+
+        
     }
 
     private boolean hasPermission() {
@@ -268,6 +274,14 @@ public class RecordWorkoutActivity extends FitoTrackActivity implements Location
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         if (hasPermission()) {
             startListener();
+        }
+
+        else {
+            new AlertDialog.Builder(this)
+                .setTitle("Permission Denied")
+                .setMessage("GPS permission is required to record the workout.")
+                .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
+                .show();
         }
     }
 


### PR DESCRIPTION
This PR addresses the use of 'ACCESS_FINE_LOCATION' permission in RecordWorkoutActivity.java by ensuring that it is necessary.

✅ Fixes: https://github.com/SOEN6431Winter2025/FitoTrackW25/issues/52

Code Change:
![image](https://github.com/user-attachments/assets/839cd003-2d71-430c-a6d9-fb9fb44a7df2)
